### PR TITLE
Update endpoint used by DenoTasks, and apply stylua

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 100
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "Input"

--- a/lua/deno-nvim/commands.lua
+++ b/lua/deno-nvim/commands.lua
@@ -1,26 +1,28 @@
-local dn = require("deno-nvim")
+local dn = require('deno-nvim')
 
 local M = {}
 
 function M.setup_lsp_commands()
-    vim.lsp.commands["deno.test"] = function(args)
-        local file = args.arguments[1]:gsub("file:///", "/")
-        local test_name = args.arguments[2]
+  vim.lsp.commands['deno.test'] = function(args)
+    local file = args.arguments[1]:gsub('file:///', '/')
+    local test_name = args.arguments[2]
 
-        if args.title == "Debug" then
-            -- test command
-            -- we use dap here
-            dn.dap.start({
-                program = file,
-                test_filter = '/^' .. test_name .. '$/',
-            })
-        else
-            -- run command
-            local cmd = "split term://deno test --no-check --unstable -A " ..
-                file .. " --filter " .. vim.fn.fnameescape("'/^" .. test_name .. "$/'")
-            vim.cmd(cmd)
-        end
+    if args.title == 'Debug' then
+      -- test command
+      -- we use dap here
+      dn.dap.start({
+        program = file,
+        test_filter = '/^' .. test_name .. '$/',
+      })
+    else
+      -- run command
+      local cmd = 'split term://deno test --no-check --unstable -A '
+        .. file
+        .. ' --filter '
+        .. vim.fn.fnameescape("'/^" .. test_name .. "$/'")
+      vim.cmd(cmd)
     end
+  end
 end
 
 return M

--- a/lua/deno-nvim/config.lua
+++ b/lua/deno-nvim/config.lua
@@ -1,60 +1,59 @@
 local M = {}
 
 local defaults = {
-    -- all the opts to send to nvim-lspconfig
-    -- these override the defaults set by deno-nvim
-    -- the defaults comes from https://github.com/denoland/vscode_deno/blob/main/package.json
-    server = {
-        settings = {
-            deno = {
-                enable = true,
-                suggest = {
-                    imports = {
-                        hosts = {
-                            ["https://crux.land"] = true,
-                            ["https://deno.land"] = true,
-                            ["https://x.nest.land"] = true
-                        }
-                    }
-                },
+  -- all the opts to send to nvim-lspconfig
+  -- these override the defaults set by deno-nvim
+  -- the defaults comes from https://github.com/denoland/vscode_deno/blob/main/package.json
+  server = {
+    settings = {
+      deno = {
+        enable = true,
+        suggest = {
+          imports = {
+            hosts = {
+              ['https://crux.land'] = true,
+              ['https://deno.land'] = true,
+              ['https://x.nest.land'] = true,
             },
-        }
-    }, -- deno lsp options
-    -- debugging stuff
-    dap = {
-        adapter = {
-            type = "server",
-            host = "localhost",
-            port = "${port}",
-            name = "dn_node",
-            executable = {
-                command = "node",
-                -- `args` needs to be set
-                -- follow the instruction here `https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#javascript-deno` to download and extract dapDebugServer
-                -- then set `args` to the full path to dapDebugServer.js + "${port}"
-                -- example:
-                -- ```lua
-                -- require("deno-nvim").setup {
-                --   dap = {
-                --     adapter = {
-                --       executable = {
-                --         args = {
-                --           "/absolute-path/to/js-debug/src/dapDebugServer.js", "${port}"
-                --         }
-                --       }
-                --     }
-                --   }
-                -- }
-                -- ```
-                args = {},
-            },
-        }
-    }
+          },
+        },
+      },
+    },
+  }, -- deno lsp options
+  -- debugging stuff
+  dap = {
+    adapter = {
+      type = 'server',
+      host = 'localhost',
+      port = '${port}',
+      name = 'dn_node',
+      executable = {
+        command = 'node',
+        -- `args` needs to be set
+        -- follow the instruction here `https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#javascript-deno` to download and extract dapDebugServer
+        -- then set `args` to the full path to dapDebugServer.js + "${port}"
+        -- example:
+        -- ```lua
+        -- require("deno-nvim").setup {
+        --   dap = {
+        --     adapter = {
+        --       executable = {
+        --         args = {
+        --           "/absolute-path/to/js-debug/src/dapDebugServer.js", "${port}"
+        --         }
+        --       }
+        --     }
+        --   }
+        -- }
+        -- ```
+        args = {},
+      },
+    },
+  },
 }
 
-
 function M.setup(options)
-    M.options = vim.tbl_deep_extend("force", {}, defaults, options or {})
+  M.options = vim.tbl_deep_extend('force', {}, defaults, options or {})
 end
 
 return M

--- a/lua/deno-nvim/custom_commands.lua
+++ b/lua/deno-nvim/custom_commands.lua
@@ -5,7 +5,7 @@ local function get_latest_version(line, on_data)
     return
   end
   -- if line doesn't resemble an http dependency, return
-  if not string.match(line, "https://") then
+  if not string.match(line, 'https://') then
     return
   end
   -- extract the url from the line
@@ -18,26 +18,31 @@ local function get_latest_version(line, on_data)
   -- extract the module name
   -- in this case its simple_shell
   local module = string.match(url, '/x/(.+@.+)')
-  local namespace = module and "x" or "std"
+  local namespace = module and 'x' or 'std'
   if not module then
     module = string.match(url, '/(std@.+)')
   end
   module = vim.split(module, '/')[1]
   -- fetch the latest version
-  local latest_url = string.format('https://apiland.deno.dev/v2/modules/%s',
-    namespace == "x" and vim.split(module, '@')[1] or "std")
+  local latest_url = string.format(
+    'https://apiland.deno.dev/v2/modules/%s',
+    namespace == 'x' and vim.split(module, '@')[1] or 'std'
+  )
 
   local uv = vim.loop
   local stdout = uv.new_pipe()
   local stderr = uv.new_pipe()
 
-  local cmd = string.format([[
+  local cmd = string.format(
+    [[
         const latest_version = await fetch("%s").then(r=>r.json()).then(r => r.latest_version)
         console.log(latest_version)
-        ]], latest_url)
-  uv.spawn("deno", {
-    args = { "eval", cmd },
-    stdio = { stdout, stderr }
+        ]],
+    latest_url
+  )
+  uv.spawn('deno', {
+    args = { 'eval', cmd },
+    stdio = { stdout, stderr },
   })
 
   if stderr ~= nil then
@@ -45,7 +50,7 @@ local function get_latest_version(line, on_data)
       assert(not err, err)
       if data then
         local latest_version = data
-        local new_module = vim.split(module, '@')[1] .. "@" .. latest_version
+        local new_module = vim.split(module, '@')[1] .. '@' .. latest_version
         new_module = vim.trim(new_module)
         if new_module == module then
           on_data()
@@ -60,11 +65,16 @@ local function get_latest_version(line, on_data)
   end
 end
 
-local namespace_id = vim.api.nvim_create_namespace("deno update")
+local namespace_id = vim.api.nvim_create_namespace('deno update')
 local function mark_line(buf, mark, start_idx)
   vim.schedule(function()
-    local extmark_id = vim.api.nvim_buf_set_extmark(buf, namespace_id, start_idx, -1,
-      { id = start_idx + 1, virt_text = { { mark } }, })
+    local extmark_id = vim.api.nvim_buf_set_extmark(
+      buf,
+      namespace_id,
+      start_idx,
+      -1,
+      { id = start_idx + 1, virt_text = { { mark } } }
+    )
     vim.defer_fn(function()
       vim.api.nvim_buf_del_extmark(buf, namespace_id, extmark_id)
     end, 3000)
@@ -83,7 +93,7 @@ function DenoUpdateImports()
           if new_line ~= nil then
             vim.api.nvim_buf_set_lines(buf, start_idx, start_idx + 1, false, { new_line })
           end
-          mark_line(buf, "✨", start_idx)
+          mark_line(buf, '✨', start_idx)
         end)
       end)
     end
@@ -101,7 +111,7 @@ function DenoUpdateImport()
         if new_line ~= nil then
           vim.api.nvim_buf_set_lines(buf, cursor_pos[1] - 1, cursor_pos[1], false, { new_line })
         end
-        mark_line(buf, "✨", cursor_pos[1] - 1)
+        mark_line(buf, '✨', cursor_pos[1] - 1)
       end)
     end)
   end
@@ -116,9 +126,9 @@ function DenoCheckImports()
       get_latest_version(line, function(new_line, new_module)
         local mark
         if new_line then
-          mark = string.format("🔺%s", new_module)
+          mark = string.format('🔺%s', new_module)
         else
-          mark = "✨"
+          mark = '✨'
         end
         mark_line(buf, mark, i - 1)
       end)
@@ -135,9 +145,9 @@ function DenoCheckImport()
     get_latest_version(line, function(new_line, new_module)
       local mark
       if new_line then
-        mark = string.format("🔺%s", new_module)
+        mark = string.format('🔺%s', new_module)
       else
-        mark = "✨"
+        mark = '✨'
       end
       mark_line(buf, mark, cursor_pos[1] - 1)
     end)
@@ -145,21 +155,21 @@ function DenoCheckImport()
 end
 
 function M.setup_custom_commands()
-  vim.api.nvim_create_user_command("Deno", function(meta)
-    if meta.args == "update_imports" then
+  vim.api.nvim_create_user_command('Deno', function(meta)
+    if meta.args == 'update_imports' then
       DenoUpdateImports()
-    elseif meta.args == "update_import" then
+    elseif meta.args == 'update_import' then
       DenoUpdateImport()
-    elseif meta.args == "check_imports" then
+    elseif meta.args == 'check_imports' then
       DenoCheckImports()
-    elseif meta.args == "check_import" then
+    elseif meta.args == 'check_import' then
       DenoCheckImport()
     end
   end, {
     nargs = 1,
     complete = function()
-      return { "update_imports", "update_import", "check_imports", "check_import" }
-    end
+      return { 'update_imports', 'update_import', 'check_imports', 'check_import' }
+    end,
   })
 end
 

--- a/lua/deno-nvim/dap.lua
+++ b/lua/deno-nvim/dap.lua
@@ -1,48 +1,48 @@
-local dn = require("deno-nvim")
+local dn = require('deno-nvim')
 
 local M = {}
 
 local function scheduled_error(err)
-    vim.schedule(function()
-        vim.notify(err, vim.log.levels.ERROR)
-    end)
+  vim.schedule(function()
+    vim.notify(err, vim.log.levels.ERROR)
+  end)
 end
 
 function M.start(args)
-    if not pcall(require, "dap") then
-        scheduled_error("nvim-dap not found.")
-        return
-    end
-    local dap = require("dap")
+  if not pcall(require, 'dap') then
+    scheduled_error('nvim-dap not found.')
+    return
+  end
+  local dap = require('dap')
 
-    local dap_config = {
-        name = "Deno debug",
-        type = 'pwa-node',
-        request = 'launch',
-        runtimeExecutable = "deno",
-        runtimeArgs = {
-            "test",
-            "--inspect-wait",
-            "--unstable",
-            "--no-check",
-            "--allow-all",
-            "--filter",
-            args.test_filter,
-        },
-        program = args.program,
-        cwd = "${workspaceFolder}",
-        attachSimplePort = 9229,
-    }
-    dap.run(dap_config)
+  local dap_config = {
+    name = 'Deno debug',
+    type = 'pwa-node',
+    request = 'launch',
+    runtimeExecutable = 'deno',
+    runtimeArgs = {
+      'test',
+      '--inspect-wait',
+      '--unstable',
+      '--no-check',
+      '--allow-all',
+      '--filter',
+      args.test_filter,
+    },
+    program = args.program,
+    cwd = '${workspaceFolder}',
+    attachSimplePort = 9229,
+  }
+  dap.run(dap_config)
 end
 
 function M.setup_adapter()
-    local dap = require("dap")
-    local opts = dn.config.options
+  local dap = require('dap')
+  local opts = dn.config.options
 
-    if opts.dap.adapter ~= false then
-        dap.adapters["pwa-node"] = opts.dap.adapter
-    end
+  if opts.dap.adapter ~= false then
+    dap.adapters['pwa-node'] = opts.dap.adapter
+  end
 end
 
 return M

--- a/lua/deno-nvim/init.lua
+++ b/lua/deno-nvim/init.lua
@@ -1,31 +1,31 @@
 local M = {
-    config = nil,
-    lsp = nil,
-    dap = nil,
+  config = nil,
+  lsp = nil,
+  dap = nil,
 }
 
 function M.setup(opts)
-    local commands = require("deno-nvim.commands")
+  local commands = require('deno-nvim.commands')
 
-    local config = require("deno-nvim.config")
-    M.config = config
+  local config = require('deno-nvim.config')
+  M.config = config
 
-    local lsp = require("deno-nvim.lsp")
-    M.lsp = lsp
+  local lsp = require('deno-nvim.lsp')
+  M.lsp = lsp
 
-    local dn_dap = require("deno-nvim.dap")
-    M.dap = dn_dap
+  local dn_dap = require('deno-nvim.dap')
+  M.dap = dn_dap
 
-    local custom_commands = require("deno-nvim.custom_commands")
+  local custom_commands = require('deno-nvim.custom_commands')
 
-    config.setup(opts)
-    lsp.setup()
-    commands.setup_lsp_commands()
-    custom_commands.setup_custom_commands()
+  config.setup(opts)
+  lsp.setup()
+  commands.setup_lsp_commands()
+  custom_commands.setup_custom_commands()
 
-    if pcall(require, "dap") then
-        dn_dap.setup_adapter()
-    end
+  if pcall(require, 'dap') then
+    dn_dap.setup_adapter()
+  end
 end
 
 return M

--- a/lua/deno-nvim/lsp.lua
+++ b/lua/deno-nvim/lsp.lua
@@ -1,153 +1,149 @@
-local dn = require("deno-nvim")
-local lspconfig = require("lspconfig")
+local dn = require('deno-nvim')
+local lspconfig = require('lspconfig')
 
 local M = {}
 
 local function virtual_text_document_handler(fname, res, client)
-    if not res or not res.result then
-        return nil
-    end
-    local result = res.result
+  if not res or not res.result then
+    return nil
+  end
+  local result = res.result
 
-    local bufnr = (function()
-        vim.cmd.vsplit()
-        vim.cmd.enew()
-        local bufnr = vim.api.nvim_get_current_buf()
-        vim.api.nvim_buf_set_name(bufnr, fname)
-        return bufnr
-    end)()
+  local bufnr = (function()
+    vim.cmd.vsplit()
+    vim.cmd.enew()
+    local bufnr = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_name(bufnr, fname)
+    return bufnr
+  end)()
 
+  local lines
+  local filetype
+  if type(result) == 'table' then
+    lines = vim.split(vim.json.encode(result), '\n')
+    filetype = 'json'
+  else
+    lines = vim.split(result, '\n')
+    filetype = 'markdown'
+  end
 
-    local lines
-    local filetype
-    if type(result) == "table" then
-        lines = vim.split(vim.json.encode(result), "\n")
-        filetype = "json"
-    else
-        lines = vim.split(result, '\n')
-        filetype = "markdown"
-    end
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
+  vim.api.nvim_buf_set_option(bufnr, 'filetype', filetype)
+  vim.lsp.buf_attach_client(bufnr, client.id)
 
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-    vim.api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
-    vim.api.nvim_buf_set_option(bufnr, 'filetype', filetype)
-    vim.lsp.buf_attach_client(bufnr, client.id)
-
-    -- format then set to readonly and remove modified flag
-    vim.lsp.buf.format()
-    vim.api.nvim_buf_set_option(bufnr, 'modified', false)
-    vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
+  -- format then set to readonly and remove modified flag
+  vim.lsp.buf.format()
+  vim.api.nvim_buf_set_option(bufnr, 'modified', false)
+  vim.api.nvim_buf_set_option(bufnr, 'readonly', true)
 end
 
 local run_on_deno = function(fn)
-    local clients = vim.lsp.get_active_clients()
-    for _, client in ipairs(clients) do
-        if client.name == 'denols' then
-            fn(client)
-            break
-        end
+  local clients = vim.lsp.get_active_clients()
+  for _, client in ipairs(clients) do
+    if client.name == 'denols' then
+      fn(client)
+      break
     end
+  end
 end
 
 local function setup_commands()
-    local lsp_opts = dn.config.options.server
+  local lsp_opts = dn.config.options.server
 
-    lsp_opts.commands = vim.tbl_deep_extend("force", lsp_opts.commands or {}, {
-        DenoPerformance = {
-            function()
-                run_on_deno(function(client)
-                    virtual_text_document_handler("performance.json", client.request_sync('deno/performance'), client)
-                end)
-            end,
-            description = "Requests the return of the timing averages for the internal instrumentation of Deno"
-        },
-        DenoReloadImportRegistries = {
-            function()
-                run_on_deno(function(client)
-                    client.request_sync('deno/reloadImportRegistries')
-                end)
-            end,
-            description = "Reloads any cached responses from import registries"
-        },
-        DenoStatus = {
-            function()
-                run_on_deno(function(client)
-                    local result = client.request_sync(
-                        'deno/virtualTextDocument',
-                        {
-                            textDocument = { uri = "deno:/status.md" },
-                        }
-                    )
-                    virtual_text_document_handler("status.md", result, client)
-                end)
-            end,
-            description = "Requests the status of the lsp"
-        },
-        DenoTask = {
-            function()
-                run_on_deno(function(client)
-                    local response = client.request_sync('deno/task')
-                    if not response then
-                        -- the server is not ready yet
-                        return
-                    end
-                    local tasks = response.result
-                    if not tasks then
-                        -- there is no tasks defined
-                        return
-                    end
+  lsp_opts.commands = vim.tbl_deep_extend('force', lsp_opts.commands or {}, {
+    DenoPerformance = {
+      function()
+        run_on_deno(function(client)
+          virtual_text_document_handler(
+            'performance.json',
+            client.request_sync('deno/performance'),
+            client
+          )
+        end)
+      end,
+      description = 'Requests the return of the timing averages for the internal instrumentation of Deno',
+    },
+    DenoReloadImportRegistries = {
+      function()
+        run_on_deno(function(client)
+          client.request_sync('deno/reloadImportRegistries')
+        end)
+      end,
+      description = 'Reloads any cached responses from import registries',
+    },
+    DenoStatus = {
+      function()
+        run_on_deno(function(client)
+          local result = client.request_sync('deno/virtualTextDocument', {
+            textDocument = { uri = 'deno:/status.md' },
+          })
+          virtual_text_document_handler('status.md', result, client)
+        end)
+      end,
+      description = 'Requests the status of the lsp',
+    },
+    DenoTask = {
+      function()
+        run_on_deno(function(client)
+          local response = client.request_sync('deno/task')
+          if not response then
+            -- the server is not ready yet
+            return
+          end
+          local tasks = response.result
+          if not tasks then
+            -- there is no tasks defined
+            return
+          end
 
-                    vim.ui.select(tasks, {
-                        prompt = 'Select deno task to run',
-                        format_item = function(task)
-                            return task.name
-                        end,
-                    }, function(choice)
-                        if choice == nil then
-                            return
-                        end
-                        vim.cmd("split term://deno task " .. choice.name)
-                    end)
-                end)
+          vim.ui.select(tasks, {
+            prompt = 'Select deno task to run',
+            format_item = function(task)
+              return task.name
             end,
-            description = "List/Run deno tasks"
-        },
-    })
+          }, function(choice)
+            if choice == nil then
+              return
+            end
+            vim.cmd('split term://deno task ' .. choice.name)
+          end)
+        end)
+      end,
+      description = 'List/Run deno tasks',
+    },
+  })
 end
 
 local function setup_handlers()
-    local lsp_opts = dn.config.options.server
-    local custom_handlers = {}
+  local lsp_opts = dn.config.options.server
+  local custom_handlers = {}
 
-    custom_handlers['deno/registryState'] = function(_, result, context)
-        -- https://github.com/denoland/vscode_deno/blob/45d343516ab1250867a5cb254460278f0ceca2a2/client/src/notification_handlers.ts
-        local client = vim.lsp.get_client_by_id(context.client_id)
-        local suggest_imports_config = (client.config.settings.deno.suggest or {}).imports or {}
-        local hosts = suggest_imports_config.hosts or {}
-        hosts[result.origin] = true
+  custom_handlers['deno/registryState'] = function(_, result, context)
+    -- https://github.com/denoland/vscode_deno/blob/45d343516ab1250867a5cb254460278f0ceca2a2/client/src/notification_handlers.ts
+    local client = vim.lsp.get_client_by_id(context.client_id)
+    local suggest_imports_config = (client.config.settings.deno.suggest or {}).imports or {}
+    local hosts = suggest_imports_config.hosts or {}
+    hosts[result.origin] = true
 
-        local new = { deno = { suggest = { imports = { hosts = hosts } } } }
-        client.config.settings = vim.tbl_deep_extend('force', client.config.settings, new)
-        client.notify('workspace/didChangeConfiguration', {
-            settings = new,
-        })
-    end
+    local new = { deno = { suggest = { imports = { hosts = hosts } } } }
+    client.config.settings = vim.tbl_deep_extend('force', client.config.settings, new)
+    client.notify('workspace/didChangeConfiguration', {
+      settings = new,
+    })
+  end
 
-    lsp_opts.handlers = vim.tbl_deep_extend(
-        "force",
-        custom_handlers,
-        lsp_opts.handlers or {}
-    )
+  lsp_opts.handlers = vim.tbl_deep_extend('force', custom_handlers, lsp_opts.handlers or {})
 end
 
 local function setup_lsp()
-    lspconfig.denols.setup(dn.config.options.server)
+  lspconfig.denols.setup(dn.config.options.server)
 end
 
 function M.setup()
-    setup_commands()
-    setup_handlers()
-    setup_lsp()
+  setup_commands()
+  setup_handlers()
+  setup_lsp()
 end
 
 return M

--- a/lua/deno-nvim/lsp.lua
+++ b/lua/deno-nvim/lsp.lua
@@ -86,7 +86,7 @@ local function setup_commands()
     DenoTask = {
       function()
         run_on_deno(function(client)
-          local response = client.request_sync('deno/task')
+          local response = client.request_sync('deno/taskDefinitions')
           if not response then
             -- the server is not ready yet
             return


### PR DESCRIPTION
Adapts change from denoland/deno#20827 (b76fa270d2199e1dd3a8c02c4f4c12f3c59a19e5) into DenoTasks command

Also, reformats with [StyLua](https://github.com/JohnnyMorganz/StyLua) to prevent errant whitespace changes, using the same configuration currently used by neovim/neovim